### PR TITLE
Run command to open folder after the dependencies finish installing

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -38,7 +38,7 @@ function activate(context) {
 					const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
 					terminal.show();
 					terminal.sendText(`cd ${projectFolder}`);
-					terminal.sendText(`twilio serverless:init ${projectName} && code ${projectName}`);
+					terminal.sendText(`twilio serverless:init ${projectName} && code ${projectName} -r`);
 				})				
 			});
 	});


### PR DESCRIPTION
Fixes #2 

**Description**

Appends `code` command to the initial `serverless:init` command to ensure that all the dependencies have finished installing before trying to open the project in a new window.

Some caveats with this approach:

- For Windows users, this will work out of the box since the `code` command is added to the PATH automatically after installation.
- For Linux/macOS users, this will work only if they've added the `code` command to the PATH after installation.

In both cases though, `serverless:init` will execute without any issues, it's just the opening the project portion that could have a problem.

A workaround for this would be to execute `serverless:init` in the background using a `child_process`, which would return a callback after execution, and use that to open the folder using VSCode API's `vscode.openFolder` command. The downside of this approach is that we wouldn't give any output to the user while `serverless:init` is running, which takes a bit of time and wouldn't be the best user experience, but open to suggestions here :)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
