### PR TITLE
Run start command in new terminal or last open after first

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,29 +1,7 @@
 const vscode = require('vscode');
 const chokidar = require('chokidar');
 const path = require('path');
-
-
-function assignTerminal(vscode, command) {
-
-	let terminal;
-
-	const terminals = vscode.window.terminals;
-	const serverTerminals = terminals.filter((terminal) => {
-		return terminal.name === 'server';
-	});
-
-	const otherTerminals = terminals.filter((terminal) => {
-		return terminal.name !== 'server';
-	})
-
-	if (command === 'start') {
-		terminal = serverTerminals.length < 1 ? vscode.window.createTerminal("server") : serverTerminals[0];
-	} else {
-		terminal = otherTerminals.length < 1 ? vscode.window.createTerminal(): otherTerminals[0];
-	}
-
-	return terminal;
-}
+const assignTerminal = require('./helpers/assignTerminal');
 
 /**
  * @param {vscode.ExtensionContext} context

--- a/helpers/assignTerminal.js
+++ b/helpers/assignTerminal.js
@@ -1,0 +1,23 @@
+function assignTerminal(vscode, command) {
+
+    let terminal;
+
+    const terminals = vscode.window.terminals;
+    const serverTerminals = terminals.filter((terminal) => {
+        return terminal.name === 'server';
+    });
+
+    const otherTerminals = terminals.filter((terminal) => {
+        return terminal.name !== 'server';
+    })
+
+    if (command === 'start') {
+        terminal = serverTerminals.length < 1 ? vscode.window.createTerminal("server") : serverTerminals[0];
+    } else {
+        terminal = otherTerminals.length < 1 ? vscode.window.createTerminal() : otherTerminals[0];
+    }
+
+    return terminal;
+}
+
+module.exports = assignTerminal;


### PR DESCRIPTION
Fixes #3 

**Description**
Runs the start command in either a new terminal or the last one that's currently open. This avoids blocking any commands that the user may be executing on the first terminal.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
