### PR TITLE
Fix bugs for list functions command and getServiceSid helper

### DIFF
--- a/commands/activate.js
+++ b/commands/activate.js
@@ -22,6 +22,9 @@ function activateFn() {
                 );
             });
         });
+    }).catch((err) => {
+        terminal.show();
+        terminal.sendText(err);
     });
 }
 

--- a/commands/list.js
+++ b/commands/list.js
@@ -1,12 +1,16 @@
 const vscode = require("vscode");
-const fs = require("fs");
-const path = require('path');
 const assignTerminal = require("../helpers/assignTerminal");
+const getServiceSid = require('../helpers/getServiceSid');
 
 function list(type = 'functions') {
   const terminal = assignTerminal(vscode, "list");
-  terminal.show();
-  terminal.sendText(`twilio serverless:list ${type}`);
+  getServiceSid(vscode).then((serviceSid) => {
+    terminal.show();
+    terminal.sendText(`twilio serverless:list ${type} --service-sid=${serviceSid}`);
+  }).catch(err => {
+    terminal.show();
+    terminal.sendText(err);
+  });
 }
 
 module.exports = list;

--- a/extension.js
+++ b/extension.js
@@ -23,7 +23,7 @@ function activate(context) {
 	const deployFunction = vscode.commands.registerCommand('extension.deploy', deploy);
  	const activateFunction = vscode.commands.registerCommand('extension.activate', activateFn);
 	const createEnvironment = vscode.commands.registerCommand('extension.createEnvironment', createEnv);
-	const listFunctions = vscode.commands.registerCommand('extension.listFunctions ',list);
+	const listFunctions = vscode.commands.registerCommand('extension.listFunctions', list);
 
 	context.subscriptions.push(
 		activateFunction,

--- a/helpers/assignTerminal.js
+++ b/helpers/assignTerminal.js
@@ -1,5 +1,4 @@
 function assignTerminal(vscode, command) {
-
     let terminal;
 
     const terminals = vscode.window.terminals;

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 				"title": "Twilio Serverless: Create Environment"
 			},
 			{
-				"command": "extension.listFunction",
+				"command": "extension.listFunctions",
 				"title": "Twilio Serverless: List Functions"
 			}
 		]


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Two things addressed in this PR:

- A broken reference to the `listFunctions` command.
- Refactor the `getServiceSid` helper to target the case when there is no `.twilio-functions` file inside the workspace.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
