### PR TITLE
Add linter, prettier and pre-commit hook

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,23 +1,20 @@
 {
-	"env": {
-		"browser": false,
-		"commonjs": true,
-		"es6": true,
-		"node": true
-	},
-	"parserOptions": {
-		"ecmaFeatures": {
-			"jsx": true
-		},
-		"sourceType": "module"
-	},
-	"rules": {
-		"no-const-assign": "warn",
-		"no-this-before-super": "warn",
-		"no-undef": "warn",
-		"no-unreachable": "warn",
-		"no-unused-vars": "warn",
-		"constructor-super": "warn",
-		"valid-typeof": "warn"
-	}
+  "extends": ["eslint-config-twilio", "plugin:prettier/recommended"],
+  "env": {
+    "browser": false,
+    "commonjs": true,
+    "es6": true,
+    "node": true
+  },
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "sourceType": "module"
+  },
+  "rules": {
+    "camelcase": ["error", { "allow": ["^child_process"] }],
+    "no-console": "off",
+    "prefer-named-capture-group": "off"
+  }
 }

--- a/commands/activate.js
+++ b/commands/activate.js
@@ -1,31 +1,39 @@
-const vscode = require('vscode');
-const assignTerminal = require('../helpers/assignTerminal');
-const getServiceSid = require('../helpers/getServiceSid');
+const vscode = require("vscode");
+const assignTerminal = require("../helpers/assignTerminal");
+const getServiceSid = require("../helpers/getServiceSid");
 
-function activateFn() {
-    const terminal = assignTerminal(vscode, 'activate')
+const activateFn = () => {
+  const terminal = assignTerminal(vscode, "activate");
 
-    getServiceSid(vscode).then((serviceSid) => {
-        vscode.window.showInputBox({
-            ignoreFocusOut: true,
-            placeHolder: "Enter the environment you want to deploy from (e.g. 'dev')...",
-        }).then(source => {
-            vscode.window.showInputBox({
-                ignoreFocusOut: true,
-                placeHolder: "Enter the environment you want to deploy to (e.g. 'prod')..."
-            }).then(destination => {
-                terminal.show();
-                terminal.sendText(
-                    `twilio serverless:activate --service-sid=${serviceSid} \
+  getServiceSid(vscode)
+    .then(serviceSid => {
+      vscode.window
+        .showInputBox({
+          ignoreFocusOut: true,
+          placeHolder:
+            "Enter the environment you want to deploy from (e.g. 'dev')..."
+        })
+        .then(source => {
+          vscode.window
+            .showInputBox({
+              ignoreFocusOut: true,
+              placeHolder:
+                "Enter the environment you want to deploy to (e.g. 'prod')..."
+            })
+            .then(destination => {
+              terminal.show();
+              terminal.sendText(
+                `twilio serverless:activate --service-sid=${serviceSid} \
                         --environment=${destination} \
                         --source-environment=${source}`
-                );
+              );
             });
         });
-    }).catch((err) => {
-        terminal.show();
-        terminal.sendText(err);
+    })
+    .catch(err => {
+      terminal.show();
+      terminal.sendText(err);
     });
-}
+};
 
 module.exports = activateFn;

--- a/commands/create-environment.js
+++ b/commands/create-environment.js
@@ -1,30 +1,34 @@
-const vscode = require('vscode');
-const assignTerminal = require('../helpers/assignTerminal');
-const getServiceSid = require('../helpers/getServiceSid');
+const vscode = require("vscode");
+const assignTerminal = require("../helpers/assignTerminal");
+const getServiceSid = require("../helpers/getServiceSid");
 
-function createEnv() {
-    const terminal = assignTerminal(vscode, 'activate');
+const createEnv = () => {
+  const terminal = assignTerminal(vscode, "activate");
 
-    getServiceSid(vscode).then((serviceSid) => {
-        vscode.window.showInputBox({
+  getServiceSid(vscode).then(serviceSid => {
+    vscode.window
+      .showInputBox({
+        ignoreFocusOut: true,
+        placeHolder: "Enter your environment unique name (e.g. 'production')..."
+      })
+      .then(uniqueName => {
+        vscode.window
+          .showInputBox({
             ignoreFocusOut: true,
-            placeHolder: "Enter your environment unique name (e.g. 'production')...",
-        }).then(uniqueName => {
-            vscode.window.showInputBox({
-                ignoreFocusOut: true,
-                placeHolder: "Enter your environment suffix (e.g. 'prod' for my-project-1234-prod.twil.io)..."
-            }).then(suffix => {
-                terminal.show();
-                terminal.sendText(
-                    `twilio api:serverless:v1:services:environments:create \
+            placeHolder:
+              "Enter your environment suffix (e.g. 'prod' for my-project-1234-prod.twil.io)..."
+          })
+          .then(suffix => {
+            terminal.show();
+            terminal.sendText(
+              `twilio api:serverless:v1:services:environments:create \
                         --service-sid=${serviceSid} \
                         --domain-suffix=${suffix} \
                         --unique-name=${uniqueName}`
-                );
-            });
-        });
-
-    });
-}
+            );
+          });
+      });
+  });
+};
 
 module.exports = createEnv;

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -1,10 +1,10 @@
-const vscode = require('vscode');
-const assignTerminal = require('../helpers/assignTerminal');
+const vscode = require("vscode");
+const assignTerminal = require("../helpers/assignTerminal");
 
-function deploy() {
-    const terminal = assignTerminal(vscode, 'deploy')
-    terminal.show();
-    terminal.sendText(`twilio serverless:deploy`);
-}
+const deploy = () => {
+  const terminal = assignTerminal(vscode, "deploy");
+  terminal.show();
+  terminal.sendText(`twilio serverless:deploy`);
+};
 
 module.exports = deploy;

--- a/commands/index.js
+++ b/commands/index.js
@@ -1,9 +1,17 @@
-const activateFn = require('./activate');
-const createEnv = require('./create-environment');
-const deploy = require('./deploy');
-const init = require('./init');
-const newFunction = require('./new-function');
-const start = require('./start');
-const list = require('./list');
+const activateFn = require("./activate");
+const createEnv = require("./create-environment");
+const deploy = require("./deploy");
+const init = require("./init");
+const newFunction = require("./new-function");
+const start = require("./start");
+const list = require("./list");
 
-module.exports = { activateFn, createEnv, deploy, init, newFunction, start, list };
+module.exports = {
+  activateFn,
+  createEnv,
+  deploy,
+  init,
+  newFunction,
+  start,
+  list
+};

--- a/commands/init.js
+++ b/commands/init.js
@@ -1,37 +1,37 @@
-const vscode = require('vscode');
-const assignTerminal = require('../helpers/assignTerminal');
+const vscode = require("vscode");
+const assignTerminal = require("../helpers/assignTerminal");
 
-function init() {
-    vscode.window
-        .showOpenDialog({
-            canSelectFiles: false,
-            canSelectFolders: true,
-            canSelectMany: false,
-            openLabel: `Create Project`,
+const init = () => {
+  vscode.window
+    .showOpenDialog({
+      canSelectFiles: false,
+      canSelectFolders: true,
+      canSelectMany: false,
+      openLabel: `Create Project`
+    })
+    .then(folder => {
+      if (!folder) {
+        return;
+      }
+      vscode.window
+        .showInputBox({
+          ignoreFocusOut: true,
+          placeHolder: "Enter your project name..."
         })
-        .then(folder => {
-            if (!folder) {
-                return;
-            }
-            vscode.window.showInputBox({
-                ignoreFocusOut: true,
-                placeHolder: 'Enter your project name...',
-            }).then(projectName => {
+        .then(projectName => {
+          if (!projectName) {
+            return;
+          }
 
-                if (!projectName) {
-                    return;
-                }
-
-                const projectFolder = folder[0].fsPath;
-
-                console.log(projectFolder);
-
-                const terminal = assignTerminal(vscode, 'init');
-                terminal.show();
-                terminal.sendText(`cd ${projectFolder}`);
-                terminal.sendText(`twilio serverless:init ${projectName} && code ${projectName} -r`);
-            });
+          const projectFolder = folder[0].fsPath;
+          const terminal = assignTerminal(vscode, "init");
+          terminal.show();
+          terminal.sendText(`cd ${projectFolder}`);
+          terminal.sendText(
+            `twilio serverless:init ${projectName} && code ${projectName} -r`
+          );
         });
-}
+    });
+};
 
 module.exports = init;

--- a/commands/list.js
+++ b/commands/list.js
@@ -1,16 +1,20 @@
 const vscode = require("vscode");
 const assignTerminal = require("../helpers/assignTerminal");
-const getServiceSid = require('../helpers/getServiceSid');
+const getServiceSid = require("../helpers/getServiceSid");
 
-function list(type = 'functions') {
+const list = (type = "functions") => {
   const terminal = assignTerminal(vscode, "list");
-  getServiceSid(vscode).then((serviceSid) => {
-    terminal.show();
-    terminal.sendText(`twilio serverless:list ${type} --service-sid=${serviceSid}`);
-  }).catch(err => {
-    terminal.show();
-    terminal.sendText(err);
-  });
-}
+  getServiceSid(vscode)
+    .then(serviceSid => {
+      terminal.show();
+      terminal.sendText(
+        `twilio serverless:list ${type} --service-sid=${serviceSid}`
+      );
+    })
+    .catch(err => {
+      terminal.show();
+      terminal.sendText(err);
+    });
+};
 
 module.exports = list;

--- a/commands/new-function.js
+++ b/commands/new-function.js
@@ -1,40 +1,44 @@
-const path = require('path');
-const vscode = require('vscode');
-const chokidar = require('chokidar');
-const assignTerminal = require('../helpers/assignTerminal');
+const path = require("path");
+const vscode = require("vscode");
+const chokidar = require("chokidar");
+const assignTerminal = require("../helpers/assignTerminal");
 
-function newFunction() {
-    return vscode.window.showInputBox({
-        ignoreFocusOut: true,
-        placeHolder: 'Enter your function name here...',
-    }).then(fnName => {
-        const wsPath = (vscode.workspace.workspaceFolders[0].uri.fsPath);
-        const fnDirPath = path.join(wsPath, 'functions');
-        const fnFilePath = path.join(fnDirPath, `${fnName}.js`);
+const newFunction = () => {
+  return vscode.window
+    .showInputBox({
+      ignoreFocusOut: true,
+      placeHolder: "Enter your function name here..."
+    })
+    .then(fnName => {
+      const wsPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+      const fnDirPath = path.join(wsPath, "functions");
+      const fnFilePath = path.join(fnDirPath, `${fnName}.js`);
 
-        if (!fnName || !wsPath) {
-            return;
+      if (!fnName || !wsPath) {
+        return;
+      }
+
+      const terminal = assignTerminal(vscode, "new");
+      terminal.show();
+      terminal.sendText(`twilio serverless:new ${fnName}`);
+
+      const fileWatcher = chokidar.watch(fnDirPath, {
+        ignored: /(^|[\/\\])\../,
+        persistent: true,
+        depth: 1
+      });
+
+      fileWatcher.on("add", addedFile => {
+        if (addedFile === fnFilePath) {
+          // Open file once created
+          vscode.workspace
+            .openTextDocument(vscode.Uri.parse(fnFilePath))
+            .then(doc => {
+              vscode.window.showTextDocument(doc, 1, false);
+            });
         }
-
-        const terminal = assignTerminal(vscode, 'new');
-        terminal.show();
-        terminal.sendText(`twilio serverless:new ${fnName}`);
-
-        const fileWatcher = chokidar.watch(fnDirPath, {
-            ignored: /(^|[\/\\])\../,
-            persistent: true,
-            depth: 1
-        });
-
-        fileWatcher.on('add', addedFile => {
-            if (addedFile === fnFilePath) {
-                // Open file once created
-                vscode.workspace.openTextDocument(vscode.Uri.parse(fnFilePath)).then(doc => {
-                    vscode.window.showTextDocument(doc, 1, false);
-                });
-            }
-        });
+      });
     });
-}
+};
 
 module.exports = newFunction;

--- a/commands/start.js
+++ b/commands/start.js
@@ -1,10 +1,10 @@
-const vscode = require('vscode');
-const assignTerminal = require('../helpers/assignTerminal');
+const vscode = require("vscode");
+const assignTerminal = require("../helpers/assignTerminal");
 
-function start() {
-    const serverTerminal = assignTerminal(vscode, 'start');
-    serverTerminal.show();
-    serverTerminal.sendText(`twilio serverless:start --live`);
-}
+const start = () => {
+  const serverTerminal = assignTerminal(vscode, "start");
+  serverTerminal.show();
+  serverTerminal.sendText(`twilio serverless:start --live`);
+};
 
 module.exports = start;

--- a/extension.js
+++ b/extension.js
@@ -1,58 +1,94 @@
-const installDependencies = require('./helpers/onInitDependencyInstaller');
+const installDependencies = require("./helpers/onInitDependencyInstaller");
 
-const vscode = require('vscode');
+const vscode = require("vscode");
 const {
-	activateFn,
-	createEnv,
-	deploy,
-	init,
-	newFunction,
-	start,
-	list
-} = require('./commands');
+  activateFn,
+  createEnv,
+  deploy,
+  init,
+  newFunction,
+  start,
+  list
+} = require("./commands");
 
 /**
  * @param {vscode.ExtensionContext} context
  */
 
-const output = vscode.window.createOutputChannel('twilio');
+const output = vscode.window.createOutputChannel("twilio");
 
-function activate(context) {
+const activate = context => {
+  console.log("Twilio Serverless for Code is now active!");
 
-	console.log('Twilio Serverless for Code is now active!');
-  
-	installDependencies(context, output);
+  installDependencies(context, output);
 
-	const createProject = vscode.commands.registerCommand('extension.init', init);
-	const createFunction = vscode.commands.registerCommand('extension.new', newFunction);
-	const startServer = vscode.commands.registerCommand('extension.start', start);
-	const deployFunction = vscode.commands.registerCommand('extension.deploy', deploy);
- 	const activateFunction = vscode.commands.registerCommand('extension.activate', activateFn);
-	const createEnvironment = vscode.commands.registerCommand('extension.createEnvironment', createEnv);
-	const listFunctions = vscode.commands.registerCommand('extension.listFunctions', list);
-	const listServices = vscode.commands.registerCommand('extension.listServices', () => {list('services')});
-	const listEnvironments = vscode.commands.registerCommand('extension.listEnvironments', () => {list('environments')});
-	const listAssets = vscode.commands.registerCommand('extension.listAssets', () => {list('assets')});
-	const listVariables = vscode.commands.registerCommand('extension.listVariables', () => {list('variables')});
+  const createProject = vscode.commands.registerCommand("extension.init", init);
+  const createFunction = vscode.commands.registerCommand(
+    "extension.new",
+    newFunction
+  );
+  const startServer = vscode.commands.registerCommand("extension.start", start);
+  const deployFunction = vscode.commands.registerCommand(
+    "extension.deploy",
+    deploy
+  );
+  const activateFunction = vscode.commands.registerCommand(
+    "extension.activate",
+    activateFn
+  );
+  const createEnvironment = vscode.commands.registerCommand(
+    "extension.createEnvironment",
+    createEnv
+  );
+  const listFunctions = vscode.commands.registerCommand(
+    "extension.listFunctions",
+    list
+  );
+  const listServices = vscode.commands.registerCommand(
+    "extension.listServices",
+    () => {
+      list("services");
+    }
+  );
+  const listEnvironments = vscode.commands.registerCommand(
+    "extension.listEnvironments",
+    () => {
+      list("environments");
+    }
+  );
+  const listAssets = vscode.commands.registerCommand(
+    "extension.listAssets",
+    () => {
+      list("assets");
+    }
+  );
+  const listVariables = vscode.commands.registerCommand(
+    "extension.listVariables",
+    () => {
+      list("variables");
+    }
+  );
 
-	context.subscriptions.push(
-		activateFunction,
-		createEnvironment,
-		createFunction,
-		createProject,
-		deployFunction,
-		startServer,
-		listFunctions,
-		listServices,
-		listEnvironments,
-		listAssets,
-		listVariables
-	);
-}
+  context.subscriptions.push(
+    activateFunction,
+    createEnvironment,
+    createFunction,
+    createProject,
+    deployFunction,
+    startServer,
+    listFunctions,
+    listServices,
+    listEnvironments,
+    listAssets,
+    listVariables
+  );
+};
 
-function deactivate() {}
+const deactivate = () => {
+  /* nothing to do for now */
+};
 
 module.exports = {
-	activate,
-	deactivate
-}
+  activate,
+  deactivate
+};

--- a/helpers/assignTerminal.js
+++ b/helpers/assignTerminal.js
@@ -1,22 +1,28 @@
-function assignTerminal(vscode, command) {
-    let terminal;
+const assignTerminal = (vscode, command) => {
+  let terminal;
 
-    const terminals = vscode.window.terminals;
-    const serverTerminals = terminals.filter((terminal) => {
-        return terminal.name === 'server';
-    });
+  const terminals = vscode.window.terminals;
+  const serverTerminals = terminals.filter(t => {
+    return t.name === "server";
+  });
 
-    const otherTerminals = terminals.filter((terminal) => {
-        return terminal.name !== 'server';
-    })
+  const otherTerminals = terminals.filter(t => {
+    return t.name !== "server";
+  });
 
-    if (command === 'start') {
-        terminal = serverTerminals.length < 1 ? vscode.window.createTerminal("server") : serverTerminals[0];
-    } else {
-        terminal = otherTerminals.length < 1 ? vscode.window.createTerminal() : otherTerminals[0];
-    }
+  if (command === "start") {
+    terminal =
+      serverTerminals.length < 1
+        ? vscode.window.createTerminal("server")
+        : serverTerminals[0];
+  } else {
+    terminal =
+      otherTerminals.length < 1
+        ? vscode.window.createTerminal()
+        : otherTerminals[0];
+  }
 
-    return terminal;
-}
+  return terminal;
+};
 
 module.exports = assignTerminal;

--- a/helpers/getServiceSid.js
+++ b/helpers/getServiceSid.js
@@ -2,42 +2,47 @@
 
 // if not, prompt for service sid from vscode
 
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-function getServiceSid(vscode) {
-    return new Promise((resolve, reject) => {
-        if (vscode.workspace.workspaceFolders.length > 0) {
-            const wsPath = (vscode.workspace.workspaceFolders[0].uri.fsPath);
-            const twilioFnFilePath = path.join(wsPath, `.twilio-functions`);
-            fs.readFile(twilioFnFilePath, (err, data) => {
-                let parsedData = {};
-                if (data) {
-                    parsedData = JSON.parse(data.toString());
-                }
-                if (err || !parsedData.serviceSid) {
-                    vscode.window.showInputBox({
-                        ignoreFocusOut: true,
-                        placeHolder: 'Enter your Service SID here...',
-                    }).then(serviceSid => {
-                        parsedData['serviceSid'] = serviceSid;
-                        const writeData = JSON.stringify(parsedData, null, 4);
-
-                        fs.writeFile(twilioFnFilePath, writeData, 'utf-8', (err) => {
-                            if (err) { reject(err); };
-
-                            resolve(serviceSid);
-                        })
-
-                    });	
-                } else {
-                    resolve(parsedData.serviceSid);
-                }
-            });   
-        } else {
-            reject('No workspace folder detected. Please init a new project.');
+const getServiceSid = vscode => {
+  return new Promise((resolve, reject) => {
+    if (vscode.workspace.workspaceFolders.length > 0) {
+      const wsPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+      const twilioFnFilePath = path.join(wsPath, `.twilio-functions`);
+      fs.readFile(twilioFnFilePath, (err, data) => {
+        let parsedData = {};
+        if (data) {
+          parsedData = JSON.parse(data.toString());
         }
-    });
-}
+        if (err || !parsedData.serviceSid) {
+          vscode.window
+            .showInputBox({
+              ignoreFocusOut: true,
+              placeHolder: "Enter your Service SID here..."
+            })
+            .then(serviceSid => {
+              parsedData.serviceSid = serviceSid;
+              const writeData = JSON.stringify(parsedData, null, 4);
+
+              fs.writeFile(twilioFnFilePath, writeData, "utf-8", error => {
+                if (error) {
+                  reject(error);
+                }
+
+                resolve(serviceSid);
+              });
+            });
+        } else {
+          resolve(parsedData.serviceSid);
+        }
+      });
+    } else {
+      reject(
+        new Error("No workspace folder detected. Please init a new project.")
+      );
+    }
+  });
+};
 
 module.exports = getServiceSid;

--- a/helpers/onInitDependencyInstaller.js
+++ b/helpers/onInitDependencyInstaller.js
@@ -1,68 +1,4 @@
-const { execFileSync } = require('child_process');
-
-function installDependencies(context, output) {
-  if (process.platform === 'darwin') {
-    try {
-      // Check if already installed via Brew on darwin.
-      execFileSync('twilio', {
-        encoding: 'utf8',
-      });
-      return;
-    } catch (e) {
-      // Not detected. Proceed will installation as normal.
-    }
-  }
-
-  const cliCheck = execFileSync(
-    'npm',
-    ['ls', '-g', 'twilio-cli', '--json'],
-    {
-      encoding: 'utf8',
-    }
-  );
-  const cliCheckNpmJSON = JSON.parse(cliCheck);
-  // npm with --json flag yields `{}` if the package is uninstalled.
-  if (isTruthy(cliCheckNpmJSON)) {
-    return;
-  }
-
-  output.show();
-  output.appendLine('`twilio-cli` is being automatically installed!');
-  output.appendLine('Running... `npm install twilio-cli -g`');
-  output.appendLine(
-    `If the package installation fails, you can manually install.`
-  );
-
-  switch (process.platform) {
-    case 'darwin':
-      output.appendLine(
-        'To manually install `twilio-cli` via Homebrew please do: `brew install twilio/brew/twilio && twilio plugins:install @twilio-labs/plugin-serverless`.'
-      );
-      break;
-    default:
-      break;
-  }
-  output.appendLine(
-    'To manually install via npm you can run the following: `npm install twilio-cli -g && twilio plugins:install @twilio-labs/plugin-serverless`'
-  );
-
-  try {
-    execFileSync('npm', ['install', '-g', 'twilio-cli'], {
-      encoding: 'utf8',
-    });
-    execFileSync(
-      'twilio',
-      ['plugins:install', '@twilio-labs/plugin-serverless'],
-      {
-        encoding: 'utf8',
-      }
-    );
-  } catch (e) {
-    output.appendLine(
-      'ERROR. Could not automatically install `twilio`. Please install manually.'
-    );
-  }
-}
+const { execFileSync } = require("child_process");
 
 /**
  * Checks if the value is truthy. Checks against the following
@@ -72,14 +8,74 @@ function installDependencies(context, output) {
  * @param o The object to check.
  * @see https://developer.mozilla.org/en-US/docs/Glossary/Truthy
  */
-function isTruthy(o) {
-  if (!!o && o.constructor === Object) {
-    return !!Object.keys(o).length;
+const isTruthy = o => {
+  if (Boolean(o) && o.constructor === Object) {
+    return Boolean(Object.keys(o).length);
   }
   if (Array.isArray(o)) {
-    return !!o.length;
+    return Boolean(o.length);
   }
-  return !!o;
-}
+  return Boolean(o);
+};
+
+const installDependencies = (context, output) => {
+  if (process.platform === "darwin") {
+    try {
+      // Check if already installed via Brew on darwin.
+      execFileSync("twilio", {
+        encoding: "utf8"
+      });
+      return;
+    } catch (e) {
+      // Not detected. Proceed will installation as normal.
+    }
+  }
+
+  const cliCheck = execFileSync("npm", ["ls", "-g", "twilio-cli", "--json"], {
+    encoding: "utf8"
+  });
+  const cliCheckNpmJSON = JSON.parse(cliCheck);
+  // npm with --json flag yields `{}` if the package is uninstalled.
+  if (isTruthy(cliCheckNpmJSON)) {
+    return;
+  }
+
+  output.show();
+  output.appendLine("`twilio-cli` is being automatically installed!");
+  output.appendLine("Running... `npm install twilio-cli -g`");
+  output.appendLine(
+    `If the package installation fails, you can manually install.`
+  );
+
+  switch (process.platform) {
+    case "darwin":
+      output.appendLine(
+        "To manually install `twilio-cli` via Homebrew please do: `brew install twilio/brew/twilio && twilio plugins:install @twilio-labs/plugin-serverless`."
+      );
+      break;
+    default:
+      break;
+  }
+  output.appendLine(
+    "To manually install via npm you can run the following: `npm install twilio-cli -g && twilio plugins:install @twilio-labs/plugin-serverless`"
+  );
+
+  try {
+    execFileSync("npm", ["install", "-g", "twilio-cli"], {
+      encoding: "utf8"
+    });
+    execFileSync(
+      "twilio",
+      ["plugins:install", "@twilio-labs/plugin-serverless"],
+      {
+        encoding: "utf8"
+      }
+    );
+  } catch (e) {
+    output.appendLine(
+      "ERROR. Could not automatically install `twilio`. Please install manually."
+    );
+  }
+};
 
 module.exports = installDependencies;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.0.0"
@@ -22,6 +22,41 @@
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
+			}
+		},
+		"@nodelib/fs.scandir": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "2.0.3",
+				"run-parallel": "^1.1.9"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+			"dev": true
+		},
+		"@nodelib/fs.walk": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.scandir": "2.1.3",
+				"fastq": "^1.6.0"
+			}
+		},
+		"@samverschueren/stream-to-observable": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+			"integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+			"dev": true,
+			"requires": {
+				"any-observable": "^0.3.0"
 			}
 		},
 		"@types/events": {
@@ -59,6 +94,12 @@
 			"integrity": "sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg==",
 			"dev": true
 		},
+		"@types/normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+			"dev": true
+		},
 		"@types/vscode": {
 			"version": "1.36.0",
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.36.0.tgz",
@@ -66,15 +107,15 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
-			"integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+			"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
 			"dev": true
 		},
 		"acorn-jsx": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
+			"integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
 			"dev": true
 		},
 		"agent-base": {
@@ -86,10 +127,20 @@
 				"es6-promisify": "^5.0.0"
 			}
 		},
+		"aggregate-error": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+			"integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+			"dev": true,
+			"requires": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			}
+		},
 		"ajv": {
-			"version": "6.10.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-			"integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+			"version": "6.10.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
@@ -125,6 +176,12 @@
 				"color-convert": "^1.9.0"
 			}
 		},
+		"any-observable": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+			"integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+			"dev": true
+		},
 		"anymatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.0.3.tgz",
@@ -142,6 +199,12 @@
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
+		},
+		"array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true
 		},
 		"astral-regex": {
 			"version": "1.0.0",
@@ -183,6 +246,32 @@
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
+		},
+		"caller-callsite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+			"dev": true,
+			"requires": {
+				"callsites": "^2.0.0"
+			},
+			"dependencies": {
+				"callsites": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+					"dev": true
+				}
+			}
+		},
+		"caller-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+			"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+			"dev": true,
+			"requires": {
+				"caller-callsite": "^2.0.0"
+			}
 		},
 		"callsites": {
 			"version": "3.1.0",
@@ -228,6 +317,18 @@
 				"readdirp": "^3.1.1"
 			}
 		},
+		"ci-info": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
+		},
+		"clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true
+		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -235,6 +336,59 @@
 			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
+			}
+		},
+		"cli-truncate": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+			"dev": true,
+			"requires": {
+				"slice-ansi": "0.0.4",
+				"string-width": "^1.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"slice-ansi": {
+					"version": "0.0.4",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
 			}
 		},
 		"cli-width": {
@@ -275,11 +429,47 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
+		"commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
+		},
+		"cosmiconfig": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+			"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+			"dev": true,
+			"requires": {
+				"import-fresh": "^2.0.0",
+				"is-directory": "^0.3.1",
+				"js-yaml": "^3.13.1",
+				"parse-json": "^4.0.0"
+			},
+			"dependencies": {
+				"import-fresh": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+					"dev": true,
+					"requires": {
+						"caller-path": "^2.0.0",
+						"resolve-from": "^3.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
+				}
+			}
 		},
 		"cross-spawn": {
 			"version": "6.0.5",
@@ -294,6 +484,12 @@
 				"which": "^1.2.9"
 			}
 		},
+		"date-fns": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+			"dev": true
+		},
 		"debug": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -307,6 +503,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
+		},
+		"dedent": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
 			"dev": true
 		},
 		"deep-is": {
@@ -324,11 +526,47 @@
 				"object-keys": "^1.0.12"
 			}
 		},
+		"del": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
+			"integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+			"dev": true,
+			"requires": {
+				"globby": "^10.0.1",
+				"graceful-fs": "^4.2.2",
+				"is-glob": "^4.0.1",
+				"is-path-cwd": "^2.2.0",
+				"is-path-inside": "^3.0.1",
+				"p-map": "^3.0.0",
+				"rimraf": "^3.0.0",
+				"slash": "^3.0.0"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+					"integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
+			}
+		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
+		},
+		"dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
+			"requires": {
+				"path-type": "^4.0.0"
+			}
 		},
 		"doctrine": {
 			"version": "3.0.0",
@@ -338,6 +576,12 @@
 			"requires": {
 				"esutils": "^2.0.2"
 			}
+		},
+		"elegant-spinner": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+			"dev": true
 		},
 		"emoji-regex": {
 			"version": "7.0.3",
@@ -352,6 +596,15 @@
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -444,6 +697,30 @@
 				"text-table": "^0.2.0"
 			}
 		},
+		"eslint-config-prettier": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.4.0.tgz",
+			"integrity": "sha512-YrKucoFdc7SEko5Sxe4r6ixqXPDP1tunGw91POeZTTRKItf/AMFYt/YLEQtZMkR2LVpAVhcAcZgcWpm1oGPW7w==",
+			"dev": true,
+			"requires": {
+				"get-stdin": "^6.0.0"
+			}
+		},
+		"eslint-config-twilio": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-twilio/-/eslint-config-twilio-1.7.0.tgz",
+			"integrity": "sha512-0WNNLXmMW2+Do8bIMAbNDDY1nixT7Qqm8NcNtnJ9fvc1MIbDdWPSPKzTwyL6RVOmJHuXpqxXEx+q0bJpIvHbdQ==",
+			"dev": true
+		},
+		"eslint-plugin-prettier": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz",
+			"integrity": "sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==",
+			"dev": true,
+			"requires": {
+				"prettier-linter-helpers": "^1.0.0"
+			}
+		},
 		"eslint-scope": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -464,9 +741,9 @@
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
 			"dev": true
 		},
 		"espree": {
@@ -505,15 +782,15 @@
 			}
 		},
 		"estraverse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
 		},
 		"esutils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
 		"execa": {
@@ -548,6 +825,36 @@
 			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 			"dev": true
 		},
+		"fast-diff": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+			"dev": true
+		},
+		"fast-glob": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
+			"integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.0",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.2"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				}
+			}
+		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -559,6 +866,15 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
+		},
+		"fastq": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
+			"integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+			"dev": true,
+			"requires": {
+				"reusify": "^1.0.0"
+			}
 		},
 		"figures": {
 			"version": "2.0.0",
@@ -651,6 +967,18 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
+		"get-own-enumerable-property-symbols": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
+			"integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==",
+			"dev": true
+		},
+		"get-stdin": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+			"dev": true
+		},
 		"get-stream": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -688,6 +1016,36 @@
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true
 		},
+		"globby": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+			"integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+			"dev": true,
+			"requires": {
+				"@types/glob": "^7.1.1",
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.0.3",
+				"glob": "^7.1.3",
+				"ignore": "^5.1.1",
+				"merge2": "^1.2.3",
+				"slash": "^3.0.0"
+			},
+			"dependencies": {
+				"ignore": {
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+					"dev": true
+				}
+			}
+		},
+		"graceful-fs": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+			"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+			"dev": true
+		},
 		"growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -701,6 +1059,23 @@
 			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				}
 			}
 		},
 		"has-flag": {
@@ -719,6 +1094,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true
+		},
+		"hosted-git-info": {
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
 			"dev": true
 		},
 		"http-proxy-agent": {
@@ -769,6 +1150,33 @@
 				}
 			}
 		},
+		"husky": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-3.0.8.tgz",
+			"integrity": "sha512-HFOsgcyrX3qe/rBuqyTt+P4Gxn5P0seJmr215LAZ/vnwK3jWB3r0ck7swbzGRUbufCf9w/lgHPVbF/YXQALgfQ==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.2",
+				"cosmiconfig": "^5.2.1",
+				"execa": "^1.0.0",
+				"get-stdin": "^7.0.0",
+				"is-ci": "^2.0.0",
+				"opencollective-postinstall": "^2.0.2",
+				"pkg-dir": "^4.2.0",
+				"please-upgrade-node": "^3.2.0",
+				"read-pkg": "^5.1.1",
+				"run-node": "^1.0.0",
+				"slash": "^3.0.0"
+			},
+			"dependencies": {
+				"get-stdin": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+					"integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+					"dev": true
+				}
+			}
+		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -800,6 +1208,12 @@
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
 			"dev": true
 		},
+		"indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -817,9 +1231,9 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
-			"integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.2.0",
@@ -828,7 +1242,7 @@
 				"cli-width": "^2.0.0",
 				"external-editor": "^3.0.3",
 				"figures": "^2.0.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.12",
 				"mute-stream": "0.0.7",
 				"run-async": "^2.2.0",
 				"rxjs": "^6.4.0",
@@ -860,6 +1274,12 @@
 			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
 			"dev": true
 		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
+		},
 		"is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -880,10 +1300,25 @@
 			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
 			"dev": true
 		},
+		"is-ci": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
+			"requires": {
+				"ci-info": "^2.0.0"
+			}
+		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
+		},
+		"is-directory": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
 			"dev": true
 		},
 		"is-extglob": {
@@ -910,6 +1345,33 @@
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"dev": true
+		},
+		"is-observable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+			"dev": true,
+			"requires": {
+				"symbol-observable": "^1.1.0"
+			}
+		},
+		"is-path-cwd": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+			"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+			"dev": true
+		},
+		"is-path-inside": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+			"integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+			"dev": true
+		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -924,6 +1386,12 @@
 			"requires": {
 				"has": "^1.0.1"
 			}
+		},
+		"is-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+			"dev": true
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -962,6 +1430,12 @@
 				"esprima": "^4.0.0"
 			}
 		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -993,6 +1467,274 @@
 				"type-check": "~0.3.2"
 			}
 		},
+		"lines-and-columns": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+			"dev": true
+		},
+		"lint-staged": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-9.4.2.tgz",
+			"integrity": "sha512-OFyGokJSWTn2M6vngnlLXjaHhi8n83VIZZ5/1Z26SULRUWgR3ITWpAEQC9Pnm3MC/EpCxlwts/mQWDHNji2+zA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.2",
+				"commander": "^2.20.0",
+				"cosmiconfig": "^5.2.1",
+				"debug": "^4.1.1",
+				"dedent": "^0.7.0",
+				"del": "^5.0.0",
+				"execa": "^2.0.3",
+				"listr": "^0.14.3",
+				"log-symbols": "^3.0.0",
+				"micromatch": "^4.0.2",
+				"normalize-path": "^3.0.0",
+				"please-upgrade-node": "^3.1.1",
+				"string-argv": "^0.3.0",
+				"stringify-object": "^3.3.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+					"integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"execa": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+					"integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.0",
+						"get-stream": "^5.0.0",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^3.0.0",
+						"onetime": "^5.1.0",
+						"p-finally": "^2.0.0",
+						"signal-exit": "^3.0.2",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"is-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+					"dev": true
+				},
+				"log-symbols": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+					"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2"
+					}
+				},
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				},
+				"npm-run-path": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+					"integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.0.0"
+					}
+				},
+				"onetime": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+					"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^2.1.0"
+					}
+				},
+				"p-finally": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+					"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+					"dev": true
+				},
+				"path-key": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+					"integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+					"integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
+		"listr": {
+			"version": "0.14.3",
+			"resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+			"integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+			"dev": true,
+			"requires": {
+				"@samverschueren/stream-to-observable": "^0.3.0",
+				"is-observable": "^1.1.0",
+				"is-promise": "^2.1.0",
+				"is-stream": "^1.1.0",
+				"listr-silent-renderer": "^1.1.1",
+				"listr-update-renderer": "^0.5.0",
+				"listr-verbose-renderer": "^0.5.0",
+				"p-map": "^2.0.0",
+				"rxjs": "^6.3.3"
+			},
+			"dependencies": {
+				"p-map": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+					"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+					"dev": true
+				}
+			}
+		},
+		"listr-silent-renderer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+			"dev": true
+		},
+		"listr-update-renderer": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+			"integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^1.1.3",
+				"cli-truncate": "^0.2.1",
+				"elegant-spinner": "^1.0.1",
+				"figures": "^1.7.0",
+				"indent-string": "^3.0.0",
+				"log-symbols": "^1.0.2",
+				"log-update": "^2.3.0",
+				"strip-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"figures": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
+					}
+				},
+				"indent-string": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
+				},
+				"log-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+					"dev": true,
+					"requires": {
+						"chalk": "^1.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
+		},
+		"listr-verbose-renderer": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+			"integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.1",
+				"cli-cursor": "^2.1.0",
+				"date-fns": "^1.27.2",
+				"figures": "^2.0.0"
+			}
+		},
 		"locate-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -1016,6 +1758,29 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1"
+			}
+		},
+		"log-update": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+			"integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^3.0.0",
+				"cli-cursor": "^2.0.0",
+				"wrap-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"wrap-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+					"integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+					"dev": true,
+					"requires": {
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0"
+					}
+				}
 			}
 		},
 		"map-age-cleaner": {
@@ -1044,6 +1809,28 @@
 					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 					"dev": true
 				}
+			}
+		},
+		"merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
+		},
+		"merge2": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+			"dev": true
+		},
+		"micromatch": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+			"dev": true,
+			"requires": {
+				"braces": "^3.0.1",
+				"picomatch": "^2.0.5"
 			}
 		},
 		"mimic-fn": {
@@ -1181,6 +1968,18 @@
 				"semver": "^5.7.0"
 			}
 		},
+		"normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1199,6 +1998,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 			"dev": true
 		},
 		"object-keys": {
@@ -1246,6 +2051,12 @@
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
+		},
+		"opencollective-postinstall": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+			"integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+			"dev": true
 		},
 		"optionator": {
 			"version": "0.8.2",
@@ -1314,6 +2125,15 @@
 				"p-limit": "^2.0.0"
 			}
 		},
+		"p-map": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+			"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+			"dev": true,
+			"requires": {
+				"aggregate-error": "^3.0.0"
+			}
+		},
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -1327,6 +2147,16 @@
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
+			}
+		},
+		"parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"dev": true,
+			"requires": {
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"path-exists": {
@@ -1353,16 +2183,97 @@
 			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
 			"dev": true
 		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true
+		},
 		"picomatch": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
 			"integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA=="
+		},
+		"pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"requires": {
+				"find-up": "^4.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				}
+			}
+		},
+		"please-upgrade-node": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+			"integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+			"dev": true,
+			"requires": {
+				"semver-compare": "^1.0.0"
+			}
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
+		},
+		"prettier": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+			"integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+			"dev": true
+		},
+		"prettier-linter-helpers": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+			"dev": true,
+			"requires": {
+				"fast-diff": "^1.1.2"
+			}
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -1385,6 +2296,32 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
+		},
+		"read-pkg": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+			"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+			"dev": true,
+			"requires": {
+				"@types/normalize-package-data": "^2.4.0",
+				"normalize-package-data": "^2.5.0",
+				"parse-json": "^5.0.0",
+				"type-fest": "^0.6.0"
+			},
+			"dependencies": {
+				"parse-json": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1",
+						"lines-and-columns": "^1.1.6"
+					}
+				}
+			}
 		},
 		"readdirp": {
 			"version": "3.1.1",
@@ -1412,6 +2349,15 @@
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
 		},
+		"resolve": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
 		"resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -1427,6 +2373,12 @@
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
 			}
+		},
+		"reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true
 		},
 		"rimraf": {
 			"version": "2.6.3",
@@ -1446,10 +2398,22 @@
 				"is-promise": "^2.1.0"
 			}
 		},
+		"run-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
+			"integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+			"dev": true
+		},
+		"run-parallel": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+			"dev": true
+		},
 		"rxjs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-			"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+			"integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -1465,6 +2429,12 @@
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
 			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+			"dev": true
+		},
+		"semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
 			"dev": true
 		},
 		"set-blocking": {
@@ -1494,6 +2464,12 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"dev": true
 		},
+		"slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true
+		},
 		"slice-ansi": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -1505,10 +2481,48 @@
 				"is-fullwidth-code-point": "^2.0.0"
 			}
 		},
+		"spdx-correct": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"dev": true,
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"dev": true
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"dev": true,
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+			"dev": true
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"string-argv": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+			"integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
 			"dev": true
 		},
 		"string-width": {
@@ -1519,6 +2533,17 @@
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
+			}
+		},
+		"stringify-object": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+			"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+			"dev": true,
+			"requires": {
+				"get-own-enumerable-property-symbols": "^3.0.0",
+				"is-obj": "^1.0.1",
+				"is-regexp": "^1.0.0"
 			}
 		},
 		"strip-ansi": {
@@ -1536,6 +2561,12 @@
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
 		},
+		"strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true
+		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -1551,14 +2582,20 @@
 				"has-flag": "^3.0.0"
 			}
 		},
+		"symbol-observable": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+			"dev": true
+		},
 		"table": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/table/-/table-5.4.1.tgz",
-			"integrity": "sha512-E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+			"integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.9.1",
-				"lodash": "^4.17.11",
+				"ajv": "^6.10.2",
+				"lodash": "^4.17.14",
 				"slice-ansi": "^2.1.0",
 				"string-width": "^3.0.0"
 			},
@@ -1635,6 +2672,12 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
+		"type-fest": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+			"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+			"dev": true
+		},
 		"typescript": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
@@ -1648,6 +2691,16 @@
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"vscode-test": {

--- a/package.json
+++ b/package.json
@@ -82,9 +82,15 @@
 		"@types/mocha": "^5.2.6",
 		"@types/node": "^10.12.21",
 		"@types/vscode": "^1.36.0",
-		"eslint": "^5.13.0",
+		"eslint": "^5.16.0",
+		"eslint-config-prettier": "^6.4.0",
+		"eslint-config-twilio": "^1.7.0",
+		"eslint-plugin-prettier": "^3.1.1",
 		"glob": "^7.1.4",
+		"husky": "^3.0.8",
+		"lint-staged": "^9.4.2",
 		"mocha": "^6.1.4",
+		"prettier": "1.18.2",
 		"typescript": "^3.3.1",
 		"vscode-test": "^1.0.0-next.0"
 	},
@@ -94,5 +100,16 @@
 	},
 	"dependencies": {
 		"chokidar": "^3.0.2"
+	},
+	"husky": {
+		"hooks": {
+			"pre-commit": "lint-staged"
+		}
+	},
+	"lint-staged": {
+		"*.js": [
+			"eslint --fix",
+			"git add"
+		]
 	}
 }

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -1,18 +1,20 @@
-const assert = require('assert');
-const { before } = require('mocha');
+const assert = require("assert");
+const { before } = require("mocha");
 
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
-const vscode = require('vscode');
+/*
+ * You can import and use all API from the 'vscode' module
+ * as well as import your extension to test it
+ */
+const vscode = require("vscode");
 // const myExtension = require('../extension');
 
-suite('Extension Test Suite', () => {
-	before(() => {
-		vscode.window.showInformationMessage('Start all tests.');
-	});
+suite("Extension Test Suite", () => {
+  before(() => {
+    vscode.window.showInformationMessage("Start all tests.");
+  });
 
-	test('Sample test', () => {
-		assert.equal(-1, [1, 2, 3].indexOf(5));
-		assert.equal(-1, [1, 2, 3].indexOf(0));
-	});
+  test("Sample test", () => {
+    assert.equal(-1, [1, 2, 3].indexOf(5));
+    assert.equal(-1, [1, 2, 3].indexOf(0));
+  });
 });

--- a/test/suite/index.js
+++ b/test/suite/index.js
@@ -1,40 +1,42 @@
-const path = require('path');
-const Mocha = require('mocha');
-const glob = require('glob');
+const path = require("path");
+const Mocha = require("mocha");
+const glob = require("glob");
 
-function run() {
-	// Create the mocha test
-	const mocha = new Mocha({
-		ui: 'tdd'
-	});
-	// Use any mocha API
-	mocha.useColors(true);
+const run = () => {
+  // Create the mocha test
+  const mocha = new Mocha({
+    ui: "tdd"
+  });
+  // Use any mocha API
+  mocha.useColors(true);
 
-	return new Promise((c, e) => {
-		glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
-			if (err) {
-				return e(err);
-			}
+  const testsRoot = path.resolve(__dirname, "..");
 
-			// Add files to the test suite
-			files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+  return new Promise((c, e) => {
+    glob("**/**.test.js", { cwd: testsRoot }, (err, files) => {
+      if (err) {
+        return e(err);
+      }
 
-			try {
-				// Run the mocha test
-				mocha.run(failures => {
-					if (failures > 0) {
-						e(new Error(`${failures} tests failed.`));
-					} else {
-						c();
-					}
-				});
-			} catch (err) {
-				e(err);
-			}
-		});
-	});
-}
+      // Add files to the test suite
+      files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+
+      try {
+        // Run the mocha test
+        return mocha.run(failures => {
+          if (failures > 0) {
+            e(new Error(`${failures} tests failed.`));
+          } else {
+            c();
+          }
+        });
+      } catch (error) {
+        return e(error);
+      }
+    });
+  });
+};
 
 module.exports = {
-	run
+  run
 };


### PR DESCRIPTION
Add a pre-commit hook to run `eslint` and `prettier`. This uses the internal JavaScript `twilio-style` config.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
